### PR TITLE
Warnings corregidos

### DIFF
--- a/ERC20 Smart Contract
+++ b/ERC20 Smart Contract
@@ -1,5 +1,6 @@
-pragma solidity >=0.6.7 <9.0.0;
+// SPDX-License-Identifier: MIT
 
+pragma solidity >=0.6.7 <9.0.0;
 
 interface ERC20 {
     function totalSupply() external view returns (uint _totalSupply);
@@ -31,12 +32,12 @@ contract Berpu is ERC20 {
     mapping (address => mapping (address => uint)) private __allowances;
 
     //the creator of the contract has the total supply and no one can create tokens
-    constructor() public {
+    constructor() {
         __balanceOf[msg.sender] = __totalSupply;
     }
 
     //constant value that does not change/  returns the amount of initial tokens to display
-    function totalSupply() public view override returns (uint _totalSupply) {
+    function totalSupply() public pure override returns (uint _totalSupply) {
         _totalSupply = __totalSupply;
     }
 


### PR DESCRIPTION
1) El warning de la línea 1 hace referencia a que falta la licencia SPDX, la licencia siempre es la primera línea de código en un Smart Contract, y aunque no es obligatoria (por eso te marca solo un warning en lugar de un error), es recomendable colocarla pues esta dictará los derechos que otros tendrán sobre tu código.

Un ejemplo de licencia es la del MIT y se coloca así... `// SPDX-License-Identifier: MIT`

2) Este warning sucede en la línea del método constructor, dado que se le está asignando un modificador de visibilidad (**public**), pero, los constructores se ejecutan solo una vez, cuando el contrato se implementa por primera vez. A diferencia de otras funciones, no se pueden llamar en un momento posterior, por lo que no son "visibles" en el sentido en que lo son las variables o funciones. Por lo cual no tiene sentido asignar un modificar de visibilidad a un constructor, pues solo se ejecutará una vez.

3) El compilador recomienda hacer **pure** la función en lugar de **view**. Las funciones view son para leer y modificar las variables de estado, mientras que las funciones pure no leen ni modifican las variables de estado, esto ayuda para recudir los costos de gas ya que las funciones pure o view tienen un costo más bajo en la EVM.
En este caso, la función lo que está haciendo es retornar el valor del **_totalsupply** sin modificarlo, por lo tanto, puede ser de tipo pure, ya que no lee ni modifica ninguna variable de estado.